### PR TITLE
[IVB-TTP] Add a channel-specific vertical timeline page for video summaries and link to it from the channel detail page using existing data-layer functions and UI patterns.

### DIFF
--- a/src/app/channel/[slug]/page.tsx
+++ b/src/app/channel/[slug]/page.tsx
@@ -84,21 +84,20 @@ export default async function ChannelPage({
                   key={summary.filename}
                   href={`/channel/${slug}/summary/${summary.filename}`}
                 >
-                  <div className="group flex w-full flex-col gap-2 rounded-xl border border-slate-800 bg-slate-900/60 p-4 text-left transition-all duration-200 hover:border-slate-700 hover:bg-slate-900/80 cursor-pointer">
-                    <p className="text-sm font-medium text-slate-200 group-hover:text-slate-50">
-                      {summary.title}
-                    </p>
-                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-400">
-                      <span className="inline-flex items-center gap-1">
-                        <Calendar className="h-3 w-3" />
-                        {summary.sourceDate}
-                      </span>
-                      {summary.duration && (
+                  <div className="group flex w-full flex-col gap-2 rounded-xl border border-slate-800 bg-slate-900/60 p-4 transition-colors hover:border-slate-700 hover:bg-slate-900">
+                    <div className="flex items-start justify-between gap-2">
+                      <h3 className="text-sm font-medium text-slate-100 group-hover:text-white transition-colors">
+                        {summary.title}
+                      </h3>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-500">
+                      {summary.sourceDate && (
                         <span className="inline-flex items-center gap-1">
-                          <Clock className="h-3 w-3" />
-                          {summary.duration}
+                          <Calendar className="h-3 w-3" />
+                          {summary.sourceDate}
                         </span>
                       )}
+                      {summary.duration && <span>{summary.duration}</span>}
                     </div>
                   </div>
                 </Link>

--- a/src/app/channel/[slug]/timeline/page.tsx
+++ b/src/app/channel/[slug]/timeline/page.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft } from 'lucide-react';
 import { getChannelDetail, listChannelSummaries } from '@/lib/data';
 import { Timeline } from '@/components/content/timeline';
 import { EmptyState } from '@/components/content/empty-state';
+import { notFound } from 'next/navigation';
 
 export default async function TimelinePage({
   params,
@@ -11,6 +12,11 @@ export default async function TimelinePage({
 }) {
   const { slug } = await params;
   const channel = await getChannelDetail(slug);
+
+  if (!channel) {
+    notFound();
+  }
+
   const summaries = await listChannelSummaries(slug);
   const items = summaries.items;
 

--- a/src/components/content/timeline.tsx
+++ b/src/components/content/timeline.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { Calendar, Clock } from 'lucide-react';
+import { Calendar, Clock, Cpu } from 'lucide-react';
 import type { SummaryMeta } from '@/types';
 
 interface TimelineProps {
@@ -9,23 +9,44 @@ interface TimelineProps {
   channelSlug: string;
 }
 
-function groupByMonth(items: SummaryMeta[]): Map<string, SummaryMeta[]> {
-  const groups = new Map<string, SummaryMeta[]>();
+interface MonthGroup {
+  key: string;
+  label: string;
+  items: SummaryMeta[];
+}
 
-  for (const item of items) {
+function groupByMonth(items: SummaryMeta[]): MonthGroup[] {
+  // Sort a copy ascending by sourceDate (data layer returns descending)
+  const sorted = [...items].sort(
+    (a, b) => new Date(a.sourceDate).getTime() - new Date(b.sourceDate).getTime(),
+  );
+
+  const labelFormatter = new Intl.DateTimeFormat('en-US', {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+
+  const groups: MonthGroup[] = [];
+  const keyMap = new Map<string, MonthGroup>();
+
+  for (const item of sorted) {
     const date = new Date(item.sourceDate);
-    const key = new Intl.DateTimeFormat('en-US', {
-      month: 'long',
-      year: 'numeric',
-      timeZone: 'UTC',
-    }).format(date);
+    const year = date.getUTCFullYear();
+    const month = date.getUTCMonth();
+    const key = `${year}-${String(month + 1).padStart(2, '0')}`;
 
-    const existing = groups.get(key);
-    if (existing) {
-      existing.push(item);
-    } else {
-      groups.set(key, [item]);
+    let group = keyMap.get(key);
+    if (!group) {
+      group = {
+        key,
+        label: labelFormatter.format(date),
+        items: [],
+      };
+      keyMap.set(key, group);
+      groups.push(group);
     }
+    group.items.push(item);
   }
 
   return groups;
@@ -44,16 +65,24 @@ function formatDate(dateStr: string): string {
 export function Timeline({ items, channelSlug }: TimelineProps) {
   const groups = groupByMonth(items);
 
+  if (groups.length === 0) {
+    return (
+      <div className="py-12 text-center text-sm text-slate-400">
+        No summaries available yet.
+      </div>
+    );
+  }
+
   return (
     <div className="relative space-y-8">
-      {Array.from(groups.entries()).map(([monthLabel, groupItems]) => (
-        <section key={monthLabel} className="relative">
+      {groups.map((group) => (
+        <section key={group.key} className="relative">
           <div className="sticky top-0 z-10 -ml-1 mb-4 w-fit rounded-md border border-slate-800 bg-slate-950/95 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-300 backdrop-blur">
-            {monthLabel}
+            {group.label}
           </div>
           <div className="relative space-y-4">
             <div className="absolute left-3 top-0 bottom-0 w-0.5 bg-slate-700" />
-            {groupItems.map((item) => (
+            {group.items.map((item) => (
               <article key={item.filename} className="relative">
                 <span className="absolute left-3 top-6 h-2 w-2 -translate-x-1/2 rounded-full bg-blue-500 ring-4 ring-slate-950" />
                 <Link
@@ -75,7 +104,8 @@ export function Timeline({ items, channelSlug }: TimelineProps) {
                       </span>
                     )}
                     {item.model && (
-                      <span className="inline-flex items-center rounded-full border border-slate-700 bg-slate-800 px-2 py-0.5 text-[11px] font-medium text-slate-200">
+                      <span className="inline-flex items-center gap-1.5">
+                        <Cpu className="h-3 w-3" />
                         {item.model}
                       </span>
                     )}


### PR DESCRIPTION
## IVB-TTP — Automated PR

> Generated by pipeline job `cmmpx8j9p0002icnodje89duj`
🔄 **Mode: Incremental** — only changed files are included in this PR


🟢 **Build Outcome: CLEAN** — all checks passed

### Implementation Plan
1. **modify** `src/components/content/timeline.tsx` — Implement or complete the client timeline component to accept items and channelSlug props, group summaries by month and year, render a vertical left-aligned timeline with sticky date headers, timeline line and dots, and clickable summary cards linking to /channel/[slug]/summary/[filename] that display title, source date, optional duration, and optional model using existing styling conventions and lucide-react icons.
2. **modify** `src/app/channel/[slug]/timeline/page.tsx` — Build or finish the server page using async params with Promise<{ slug: string }> and await params, fetch channel detail and summaries directly from @/lib/data, render a back link to the channel page, show the page title as channel name plus Timeline, pass summary items into the Timeline component, and display EmptyState when no summaries exist.
3. **modify** `src/app/channel/[slug]/page.tsx` — Add or refine the View Timeline link between the channel header and the Video Summaries section, pointing to /channel/${slug}/timeline and styled as an inline secondary action with a Clock icon consistent with the existing page layout.

### Code Review Verdict
✅ Approved



<details>
<summary><h3>📊 Build Retrospective</h3></summary>

#### Cost & Token Breakdown

**Total: $0.2838 USD** | 6 agent runs | 75s wall time

| Agent | Model | Tokens | Cost | % | Duration |
|---|---|---:|---:|---:|---|
| planner | gpt-5.4 | 3,514 | $0.0134 | 5% | 4.2s |
| coder | claude-opus-4-6 | 4,695 | $0.0214 | 8% | 6.9s |
| reviewer | gpt-5.4 | 6,639 | $0.0260 | 9% | 8.7s |
| designer | gpt-5.4 | 8,884 | $0.0827 | 29% | 43.0s |
| validator | gpt-5.4 | 6,230 | $0.0293 | 10% | 12.2s |

#### Quality Gates

✅ **Validator:** Passed — clean first pass

✅ **Tests:** Tests passed

#### Feedback Loops

_No feedback loops needed — clean first pass._

#### Sprint Metrics

| Metric | Value |
|---|---|
| Files generated | 3 |
| Total agent runs | 6 |
| Review retries | 0 |
| Validator fix passes | 0 |
| Review issues flagged | 0 |

</details>

---
_This PR was opened automatically by [IVB-TTP](https://github.com/ro-ro-b/ivb-ttp)._